### PR TITLE
license: state the license once as CC BY-SA 4.0

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,8 +1,9 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 = Contributing to the Heading for the Yocto Project book
 
 == Licensing
 
-By opening a pull request to this repository, you agree to provide your work under the [project license](LICENSE.adoc).
+By opening a pull request to this repository, you agree to provide your work under the link:LICENSE[project license], the Creative Commons Attribution-ShareAlike 4.0 International License (`CC-BY-SA-4.0`).
 
 Also, you agree to grant such license of your work as is required for the purposes of future print editions to @otavio and @angolini.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,439 @@
+Copyright (c) 2015-2026 Otavio Salvador, Daiane Angolini and the
+Heading for the Yocto Project contributors.
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+This work is licensed under the Creative Commons Attribution-ShareAlike
+4.0 International License. To view a copy of this license, visit
+https://creativecommons.org/licenses/by-sa/4.0/
+
+The full text of the license follows.
+
+Attribution-ShareAlike 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative
+     Commons as essentially the equivalent of this Public License.
+
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  e. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  f. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  g. License Elements means the license attributes listed in the name
+     of a Creative Commons Public License. The License Elements of this
+     Public License are Attribution and ShareAlike.
+
+  h. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  i. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  j. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  k. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  l. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  m. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. Additional offer from the Licensor -- Adapted Material.
+               Every recipient of Adapted Material from You
+               automatically receives an offer from the Licensor to
+               exercise the Licensed Rights in the Adapted Material
+               under the conditions of the Adapter's License You apply.
+
+            c. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+  b. ShareAlike.
+
+     In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the following conditions also apply.
+
+       1. The Adapter's License You apply must be a Creative Commons
+          license with the same License Elements, this version or
+          later, or a BY-SA Compatible License.
+
+       2. You must include the text of, or the URI or hyperlink to, the
+          Adapter's License You apply. You may satisfy this condition
+          in any reasonable manner based on the medium, means, and
+          context in which You Share Adapted Material.
+
+       3. You may not offer or impose any additional or different terms
+          or conditions on, or apply any Effective Technological
+          Measures to, Adapted Material that restrict exercise of the
+          rights granted under the Adapter's License You apply.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material,
+     including for purposes of Section 3(b); and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/LICENSE.adoc
+++ b/LICENSE.adoc
@@ -1,3 +1,0 @@
-This work is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 3.0 Unported License.
-
-To view a copy of this license, visit http://creativecommons.org/licenses/by-nc-sa/3.0/ or send a letter to Creative Commons, 171 Second Street, Suite 300, San Francisco, California, 94105, USA.

--- a/README.adoc
+++ b/README.adoc
@@ -1,8 +1,9 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 = Heading for the Yocto Project
 
 Welcome to the first edition of the Heading for the Yocto Project book.
 
-This book is open source under a Creative Commons license.
+This book is free content. It is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (`CC-BY-SA-4.0`). See the link:LICENSE[LICENSE] file for the full terms.
 
 == How To Generate the Book
 

--- a/book/01-The-Yocto-Project/chapter.adoc
+++ b/book/01-The-Yocto-Project/chapter.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 [[yp]]
 == The Yocto Project
 

--- a/book/01-The-Yocto-Project/sections/The-Poky-build-system.adoc
+++ b/book/01-The-Yocto-Project/sections/The-Poky-build-system.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === The Poky build system
 
 The Yocto Project computing machine represented in <<yp-input-output>> refers to the Yocto Project's reference build system, called _Poky_, which is composed by a set of files to provide the information required for the build orchestration tool's work.

--- a/book/01-The-Yocto-Project/sections/The-Yocto-Project-seen-as-a-Computing-Machine.adoc
+++ b/book/01-The-Yocto-Project/sections/The-Yocto-Project-seen-as-a-Computing-Machine.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === The Yocto Project seen as a Computing Machine
 
 A simple way to understand what the results of Yocto Project are is to represent it as a computing machine. In short, we need to describe our requirements to the Yocto Project tools, those are interpreted and the desired set of outputs are generated. A basic overview of the process done can be seen in <<yp-input-output>>:

--- a/book/01-The-Yocto-Project/sections/The-alliance-of-OpenEmbedded-Project-and-Yocto-Project.adoc
+++ b/book/01-The-Yocto-Project/sections/The-alliance-of-OpenEmbedded-Project-and-Yocto-Project.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === The alliance of OpenEmbedded Project and Yocto Project
 
 Around January 2003, some core developers from the OpenZaurus Project started to extend the range of devices supported by the build system, adding support for different devices. This new build system was eventually renamed as _OpenEmbedded build system_. The OpenEmbedded build system was composed by a task scheduler, called BitBake, and a set of metadata, including a huge software collection and BSP packages.

--- a/book/01-The-Yocto-Project/sections/What-the-Yocto-Project-is.adoc
+++ b/book/01-The-Yocto-Project/sections/What-the-Yocto-Project-is.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === What the Yocto Project is
 
 The Yocto Project started as a collaboration of many hardware manufacturers, open source operating systems, vendors, and electronics companies in 2010. The driving force for the workgroup creation was the necessity to reduce their work duplication, providing resources and information catering to both new and experienced users. The Yocto Project is a Linux Foundation workgroup and is defined as:

--- a/book/02-Benefits-for-your-products/chapter.adoc
+++ b/book/02-Benefits-for-your-products/chapter.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 == Benefits for your products
 
 The Yocto Project has been adopted by several companies, organizations and individuals. But why?

--- a/book/02-Benefits-for-your-products/sections/License-compliance-and-management.adoc
+++ b/book/02-Benefits-for-your-products/sections/License-compliance-and-management.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === License compliance and management
 
 The Yocto Project aids the license compliance and management in products. It does not inform us what is required to be compliant with one or more licenses, but it produces a set of outputs which help our legal team and technical department to do that.

--- a/book/02-Benefits-for-your-products/sections/Maximize-the-work-reuse.adoc
+++ b/book/02-Benefits-for-your-products/sections/Maximize-the-work-reuse.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === Maximize the work reuse
 
 One of most common engineers' habit is to reinvent the wheel. Even though it can be an exciting exercise and a learning tool, sometimes it leads to work duplication and energy waste only. The wheel-reinventing disease is specially problematic when it happens inside companies, mainly if it has no relation to its core business.

--- a/book/02-Benefits-for-your-products/sections/Risk-reduction.adoc
+++ b/book/02-Benefits-for-your-products/sections/Risk-reduction.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === Risk reduction
 
 We assume risks all the time. As in life, we should mitigate them when working on product development. The Yocto Project use helps us to reduce some risks.

--- a/book/03-Heading-for-Yocto-Project/chapter.adoc
+++ b/book/03-Heading-for-Yocto-Project/chapter.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 == Heading for Yocto Project
 
 At first glance, the way our companies and projects may use the Yocto Project are not obvious because it is very flexible and adapts to different team sizes and workflows and it is usually seen just as a task automation tool.

--- a/book/03-Heading-for-Yocto-Project/sections/Outsourcing.adoc
+++ b/book/03-Heading-for-Yocto-Project/sections/Outsourcing.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === Outsourcing
 
 One of the big advantages of using the Yocto Project is the freedom to choose what best fits our project.

--- a/book/03-Heading-for-Yocto-Project/sections/Planning-for-Yocto-Project.adoc
+++ b/book/03-Heading-for-Yocto-Project/sections/Planning-for-Yocto-Project.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === Planning for Yocto Project
 
 There are several distinct approaches used in software development. A common phase in most of them is the feature specification, which is critical for the understanding of all involved requirements.

--- a/book/04-The-Yocto-Project-community-ecosystem/chapter.adoc
+++ b/book/04-The-Yocto-Project-community-ecosystem/chapter.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 == The Yocto Project community ecosystem
 
 One of the biggest benefits of the Yocto Project is its community ecosystem.  In order to participate of this community it is important to develop the ability to properly communicate and contribute in a synergistic way.

--- a/book/04-The-Yocto-Project-community-ecosystem/sections/Documentation.adoc
+++ b/book/04-The-Yocto-Project-community-ecosystem/sections/Documentation.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === Documentation
 
 The Yocto Project documentation is perfect as a long term reference, when we are aware of what we are looking for, and has a base knowledge about its tools. This set of documents, along with this book, are a powerful combination to have around during the journey, diving into the Yocto Project.

--- a/book/04-The-Yocto-Project-community-ecosystem/sections/The-Yocto-Projects-communication-channels.adoc
+++ b/book/04-The-Yocto-Project-community-ecosystem/sections/The-Yocto-Projects-communication-channels.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === The Yocto Project's communication channels
 
 The Yocto Project community has a lot of similarities with the Linux kernel community as it congregates companies, other open source projects and individuals. For someone used to participate on these communities, it may be clear how to act, however it is important to bear in mind that each community has its own particularities and communication channels.

--- a/book/04-The-Yocto-Project-community-ecosystem/sections/What-is-a-community.adoc
+++ b/book/04-The-Yocto-Project-community-ecosystem/sections/What-is-a-community.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 === What a community is
 
 Providing a definition for a community is restricting it. A community is a moving organism and the perception of it varies depending on the background and previous experiences with other communities. For example, some people believe the community is composed just by the people who send code contributions to it, others see the users and partners as part of the community.

--- a/book/Heading-for-the-Yocto-Project.adoc
+++ b/book/Heading-for-the-Yocto-Project.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 Heading for the Yocto Project
 =============================
 Otavio Salvador, Daiane Angolini
@@ -7,7 +8,12 @@ v1.0, 2016-09-08
 :toclevels: 2
 :pagenums:  1
 :front-cover-image: image:cover.png[]
-:copyright: CC-BY-SA 3.0
+// The license is stated once here. Every other place in the book uses
+// these attributes, so the statements cannot drift apart.
+:license-id:   CC-BY-SA-4.0
+:license-name: Creative Commons Attribution-ShareAlike 4.0 International License
+:license-url:  https://creativecommons.org/licenses/by-sa/4.0/
+:copyright: {license-id}
 
 include::preface.adoc[]
 

--- a/book/appendix.adoc
+++ b/book/appendix.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 http://www.yoctoproject.org/docs/current/ref-manual/ref-manual.html[Yocto Project Reference Manual]
 
 Yocto Project Reference Manual: http://www.yoctoproject.org/docs/1.6/ref-manual/ref-manual.html

--- a/book/preface.adoc
+++ b/book/preface.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 == About this booklet
 
 [cols="1,2"]
@@ -6,7 +7,7 @@
 |Heading for Yocto Project
 
 |*License*
-|Creative Commons Attribution-ShareAlike 3.0 United States License
+|{license-name}
 
 |*Author*
 |Otavio Salvador <otavio@ossystems.com.br>
@@ -24,7 +25,7 @@
 [preface]
 == Preface
 
-This booklet is being developed collaboratively. The development takes place at the https://github.com/CollaborativeWritersHub/heading-for-the-yocto-project[GitHub] and the content is licensed under http://creativecommons.org/licenses/by-sa/3.0/us/[Creative Commons Attribution-ShareAlike 3.0 United States License].
+This booklet is being developed collaboratively. The development takes place at the https://github.com/CollaborativeWritersHub/heading-for-the-yocto-project[GitHub] and the content is licensed under {license-url}[{license-name}].
 
 As the content of the booklet is constantly being improved we don't have an errata, instead we would be thankful if you could report any https://github.com/CollaborativeWritersHub/heading-for-the-yocto-project/issues[issue] you find so we can address it as soon as possible. If you want to contribute, https://github.com/CollaborativeWritersHub/heading-for-the-yocto-project/pulls[pull requests] are also welcome ;-)
 

--- a/doc/list-words-to-check.adoc
+++ b/doc/list-words-to-check.adoc
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
 . file system -> filesystem
 . will
 . you -> only allowed on tips or notes


### PR DESCRIPTION
Fixes #164.

The repository stated its license in four places and the statements did not agree. `LICENSE.adoc`
carried a NonCommercial restriction that the other three did not. GitHub reported `NOASSERTION`.

## What this changes

1. `LICENSE.adoc` becomes `LICENSE`, a plain file that holds the full CC BY-SA 4.0 legal code, so
   GitHub can detect it. It names the copyright holder and the year.
2. `book/Heading-for-the-Yocto-Project.adoc` defines the license once, as the `:license-id:`,
   `:license-name:` and `:license-url:` attributes.
3. `book/preface.adoc` uses those attributes, so the two statements cannot drift apart again.
4. `README.adoc` and `CONTRIBUTING.adoc` name the same license and link to the new file.
5. Every AsciiDoc source carries an `SPDX-License-Identifier` header.

## Version 4.0

Version 4.0 is jurisdiction-neutral by design, so it removes the Unported/United States ambiguity
at the root.

## Please read before you merge

This **broadens** the rights granted, because it drops the NonCommercial clause. Five people other
than the author of this pull request contributed content: @angolini, and also André Glória,
Michelle Silva and Mario Domenech Goulart. Their agreement is not yet on record.

## Verification

`asciidoctor` builds the HTML output with no error. The output shows the 4.0 license name and URL.
The SPDX comments do not appear in the output. The GitHub license detection is not verified here;
it runs after the merge.