### PR TITLE
Make LICENSE verbatim so GitHub detects it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,3 @@
-Copyright (c) 2015-2026 Otavio Salvador, Daiane Angolini and the
-Heading for the Yocto Project contributors.
-
-SPDX-License-Identifier: CC-BY-SA-4.0
-
-This work is licensed under the Creative Commons Attribution-ShareAlike
-4.0 International License. To view a copy of this license, visit
-https://creativecommons.org/licenses/by-sa/4.0/
-
-The full text of the license follows.
-
 Attribution-ShareAlike 4.0 International
 
 =======================================================================

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+Copyright (c) 2015-2026 Otavio Salvador, Daiane Angolini and the
+Heading for the Yocto Project contributors.
+
+SPDX-License-Identifier: CC-BY-SA-4.0
+
+This work is licensed under the Creative Commons Attribution-ShareAlike
+4.0 International License. To view a copy of this license, visit
+https://creativecommons.org/licenses/by-sa/4.0/
+
+The full license text is in the LICENSE file. That file holds the license
+verbatim and unmodified, with nothing before or after it, so that
+automated license detection can identify it.

--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,7 @@
 
 Welcome to the first edition of the Heading for the Yocto Project book.
 
-This book is free content. It is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (`CC-BY-SA-4.0`). See the link:LICENSE[LICENSE] file for the full terms.
+This book is free content. It is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License (`CC-BY-SA-4.0`). See the link:LICENSE[LICENSE] file for the full terms, and the link:NOTICE[NOTICE] file for the copyright holders.
 
 == How To Generate the Book
 


### PR DESCRIPTION
Follow-up to #165, which fixed the conflicting license statements but did
not produce a license badge.

**GitHub still reports `NOASSERTION` for this repository after #165
merged.** The detection ran on the merge and failed.

## Cause

`LICENSE` holds the correct CC BY-SA 4.0 legal code, but a ten-line
preamble sits in front of it — a copyright line, an SPDX line, a summary
sentence and "The full text of the license follows."

GitHub's detector strips a *leading copyright notice* and nothing else. The
remaining sentences count as added content, which pushes the file below the
similarity threshold the detector requires, so it falls back to "Other".

## Change

- `LICENSE` now holds the CC BY-SA 4.0 text verbatim, with nothing before
  or after it.
- The preamble moves to a new `NOTICE` file, which is where the copyright
  holders and the SPDX identifier now live.
- `README.adoc` points at `NOTICE` for the copyright holders, and still
  points at `LICENSE` for the terms.

No license terms change. This is only about where the text sits.

## Verification

The license text itself is byte-identical to what #165 added, minus the
first eleven lines. Detection on the branch is checked with
`GET /repos/.../license?ref=license-detectable` and reported in a comment
below.