### PR TITLE
List the contributors instead of a TODO

### DIFF
--- a/book/contributors.adoc
+++ b/book/contributors.adoc
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: CC-BY-SA-4.0
+//
+// The names below come from the git history of this repository. To list the
+// contributors again, run:
+//
+//   git log --format='%an' | grep -viE 'dependabot|\[bot\]' | sort -u
+//
+// That command sorts by given name. The list below is ordered by family
+// name, so place new contributors by hand.
+
+* Daiane Angolini
+* Changhyeok Bae
+* André Glória
+* Mario Domenech Goulart
+* Otavio Salvador
+* Michelle Silva

--- a/book/preface.adoc
+++ b/book/preface.adoc
@@ -51,8 +51,8 @@ WARNING: This element indicates a warning or caution.
 
 == Acknowledgments
 
-The people which has contributed to this book is:
+These people have contributed to this book:
 
-TODO:: generate the list of contributors
+include::contributors.adoc[]
 
 :numbered:


### PR DESCRIPTION
Fixes two loose ends that face the reader.

1. The preface Acknowledgments section read `TODO:: generate the list of
   contributors`. That **renders into the published book**.
2. `CONTRIBUTING.adoc` tells contributors "you'll be included in the
   link:book/contributors.adoc[contributors list]", but that file did not
   exist, so the link was broken.

## Change

- Add `book/contributors.adoc` with the six people the git history records.
- Include it from the preface, in place of the TODO.
- Correct the sentence that introduces the list. It read "The people which
  has contributed to this book is:".

## The list

Taken from `git log --format='%an'` with the three dependabot identities
excluded. Six human contributors, ordered by family name:

Daiane Angolini, Changhyeok Bae, André Glória, Mario Domenech Goulart,
Otavio Salvador, Michelle Silva.

The file carries a comment with the command that produced it, so the next
person can refresh it.

**Names only, no e-mail addresses.** Publishing personal addresses in a
book is not necessary, and the git history already holds them for anyone
who needs to make contact.

## Verification

Built with `asciidoctor 2.0.26`. The HTML output shows all six names in the
Acknowledgments section, the TODO is gone from that section, and the SPDX
header comments do not appear in the output.

Note the build could not be run through `nix develop` — see the separate
issue about the development shell.